### PR TITLE
Correct name of package produced by make in OS X documentation

### DIFF
--- a/osx/README.md
+++ b/osx/README.md
@@ -4,4 +4,4 @@ Installation [instructions](https://docs.docker.com/mac/started/) available on t
 
 ##How to build
 
-Running `make` will produce a `Docker.pkg` installer.
+Running `make` will produce a `DockerToolbox.pkg` installer.


### PR DESCRIPTION
The installation package produced by `make` is `DockerToolbox.pkg`. Updated OS X readme.