### PR TITLE
Workaround for docker-machine argument bug

### DIFF
--- a/osx/mpkg/Docker Quickstart Terminal.app/Contents/Resources/Scripts/start.sh
+++ b/osx/mpkg/Docker Quickstart Terminal.app/Contents/Resources/Scripts/start.sh
@@ -25,7 +25,7 @@ if [ $VM_EXISTS_CODE -eq 1 ]; then
   echo "Creating Machine $VM..."
   $DOCKER_MACHINE rm -f $VM &> /dev/null
   rm -rf ~/.docker/machine/machines/$VM
-  $DOCKER_MACHINE -D create -d virtualbox --virtualbox-memory 2048 $VM
+  $DOCKER_MACHINE --debug create -d virtualbox --virtualbox-memory 2048 $VM
 else
   echo "Machine $VM already exists in VirtualBox."
 fi


### PR DESCRIPTION
`docker-machine -D` borks the start.sh script and results in a vm that requires a password to access. Using `--debug` allows the vm to be created without error.

See https://github.com/docker/machine/issues/1722