### PR TITLE
Add proxy variables to docker-machine command if they exists

### DIFF
--- a/osx/mpkg/quickstart.app/Contents/Resources/Scripts/start.sh
+++ b/osx/mpkg/quickstart.app/Contents/Resources/Scripts/start.sh
@@ -29,7 +29,17 @@ VM_EXISTS_CODE=$?
 if [ $VM_EXISTS_CODE -eq 1 ]; then
   "${DOCKER_MACHINE}" rm -f "${VM}" &> /dev/null
   rm -rf ~/.docker/machine/machines/"${VM}"
-  "${DOCKER_MACHINE}" create -d virtualbox --virtualbox-memory 2048 --virtualbox-disk-size 204800 "${VM}"
+  #set proxy variables if they exists
+  if [ -n ${HTTP_PROXY+x} ]; then
+	PROXY_ENV="$PROXY_ENV --engine-env HTTP_PROXY=$HTTP_PROXY"
+  fi
+  if [ -n ${HTTPS_PROXY+x} ]; then
+	PROXY_ENV="$PROXY_ENV --engine-env HTTPS_PROXY=$HTTPS_PROXY"
+  fi
+  if [ -n ${NO_PROXY+x} ]; then
+	PROXY_ENV="$PROXY_ENV --engine-env NO_PROXY=$NO_PROXY"
+  fi  
+  "${DOCKER_MACHINE}" create -d virtualbox $PROXY_ENV --virtualbox-memory 2048 --virtualbox-disk-size 204800 "${VM}"
 fi
 
 VM_STATUS="$(${DOCKER_MACHINE} status ${VM} 2>&1)"

--- a/windows/start.sh
+++ b/windows/start.sh
@@ -33,7 +33,17 @@ set -e
 if [ $VM_EXISTS_CODE -eq 1 ]; then
   "${DOCKER_MACHINE}" rm -f "${VM}" &> /dev/null || :
   rm -rf ~/.docker/machine/machines/"${VM}"
-  "${DOCKER_MACHINE}" create -d virtualbox "${VM}"
+  #set proxy variables if they exists
+  if [ -n ${HTTP_PROXY+x} ]; then
+	PROXY_ENV="$PROXY_ENV --engine-env HTTP_PROXY=$HTTP_PROXY"
+  fi
+  if [ -n ${HTTPS_PROXY+x} ]; then
+	PROXY_ENV="$PROXY_ENV --engine-env HTTPS_PROXY=$HTTPS_PROXY"
+  fi
+  if [ -n ${NO_PROXY+x} ]; then
+	PROXY_ENV="$PROXY_ENV --engine-env NO_PROXY=$NO_PROXY"
+  fi  
+  "${DOCKER_MACHINE}" create -d virtualbox $PROXY_ENV "${VM}"
 fi
 
 VM_STATUS="$(${DOCKER_MACHINE} status ${VM} 2>&1)"


### PR DESCRIPTION
This attempt to solve the proxy issue when installing docker-toolbox on windows, but i believe the same mechanism could be used on mac as well. See #78. There is still work to be done for Kitematic.

This solution use the `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` system variables and pass them to the `docker-machine` `--engine-env` parameters.

Don't forget to set the NO_PROXY system variable with at least the 192.168.99.100/101/102/103... IPs and dns names used to access local servers like 'kitematic', 'default', 'dev'.

This successfully launch the Docker Quickstart Terminal on windows if you set your *_PROXY variables as environnement variables before the first launch (in Control Panel). I believe this is the standard way to set proxy infos on Windows, Mac and Linux.
