### PR TITLE
Fixed #186, boot2dockeriso postinstall can get more as one user

### DIFF
--- a/osx/mpkg/boot2dockeriso.pkg/Scripts/postinstall
+++ b/osx/mpkg/boot2dockeriso.pkg/Scripts/postinstall
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CONSOLE_USER=$(ps aux | grep console | grep -v grep | cut -d' ' -f1)
+CONSOLE_USER=$(ps aux | grep "loginwindow console" | grep -v grep | grep -v root | cut -d' ' -f1)
 
 # Place boot2docker ISO in cache
 mkdir -p ~/.docker/machine/cache
@@ -11,4 +11,3 @@ chown -R $CONSOLE_USER:staff ~/.docker
 chown -R $CONSOLE_USER:admin /usr/local/bin/docker
 chown -R $CONSOLE_USER:admin /usr/local/bin/docker-machine
 chown -R $CONSOLE_USER:admin /usr/local/bin/docker-compose
-


### PR DESCRIPTION
See #186 for details.

You can end up with more as one user. This way you only grep only for the logged in user.