### PR TITLE
Fix shell selection at bottom of quickstart

### DIFF
--- a/osx/mpkg/quickstart.app/Contents/Resources/Scripts/start.sh
+++ b/osx/mpkg/quickstart.app/Contents/Resources/Scripts/start.sh
@@ -56,9 +56,8 @@ echo
 
 eval $($DOCKER_MACHINE env $VM --shell=bash)
 
-USER_SHELL=$(dscl /Search -read /Users/$USER UserShell | uniq | awk '{print $2}')
-if [ "$USER_SHELL" = "/bin/bash" ] || [ "$USER_SHELL" = "/bin/zsh" ] || [ "$USER_SHELL" = "/bin/sh" ]; then
-  $USER_SHELL --login
+if [ "$SHELL" = "/bin/bash" ] || [ "$SHELL" = "/bin/zsh" ] || [ "$SHELL" = "/bin/sh" ]; then
+  $SHELL --login
 else
-  $USER_SHELL
+  $SHELL
 fi

--- a/osx/mpkg/quickstart.app/Contents/Resources/Scripts/start.sh
+++ b/osx/mpkg/quickstart.app/Contents/Resources/Scripts/start.sh
@@ -56,7 +56,7 @@ echo
 
 eval $($DOCKER_MACHINE env $VM --shell=bash)
 
-USER_SHELL=$(dscl /Search -read /Users/$USER UserShell | awk '{print $2}')
+USER_SHELL=$(dscl /Search -read /Users/$USER UserShell | uniq | awk '{print $2}')
 if [ "$USER_SHELL" = "/bin/bash" ] || [ "$USER_SHELL" = "/bin/zsh" ] || [ "$USER_SHELL" = "/bin/sh" ]; then
   $USER_SHELL --login
 else


### PR DESCRIPTION
The environment variables are not properly initialized if the final bash command fails when starting Quickstart Terminal app.


                        ##         .
                  ## ## ##        ==
               ## ## ## ## ##    ===
           /"""""""""""""""""\___/ ===
      ~~~ {~~ ~~~~ ~~~ ~~~~ ~~~ ~ /  ===- ~~~
           \______ o           __/
             \    \         __/
              \____\_______/


docker is configured to use the default machine with IP 192.168.99.100
For help getting started, check out the docs at https://docs.docker.com

/bin/bash: /bin/bash: cannot execute binary file

Solution: Added pipe to 'uniq' command in remove duplicate lines that are the output of the dscl command.  For example,

$ dscl /Search -read /Users/$USER UserShell
UserShell: /bin/bash
UserShell: /bin/bash

$ dscl /Search -read /Users/$USER UserShell | uniq
UserShell: /bin/bash