### PR TITLE
Start default machine with dynamic disk size of max 1 TB instead of 20 GB

### DIFF
--- a/osx/mpkg/quickstart.app/Contents/Resources/Scripts/start.sh
+++ b/osx/mpkg/quickstart.app/Contents/Resources/Scripts/start.sh
@@ -25,7 +25,7 @@ if [ $VM_EXISTS_CODE -eq 1 ]; then
   echo "Creating Machine $VM..."
   $DOCKER_MACHINE rm -f $VM &> /dev/null
   rm -rf ~/.docker/machine/machines/$VM
-  $DOCKER_MACHINE create -d virtualbox --virtualbox-memory 2048 --virtualbox-disk-size 1048576 $VM
+  $DOCKER_MACHINE create -d virtualbox --virtualbox-memory 2048 --virtualbox-disk-size 256000 $VM
 else
   echo "Machine $VM already exists in VirtualBox."
 fi

--- a/osx/mpkg/quickstart.app/Contents/Resources/Scripts/start.sh
+++ b/osx/mpkg/quickstart.app/Contents/Resources/Scripts/start.sh
@@ -25,7 +25,7 @@ if [ $VM_EXISTS_CODE -eq 1 ]; then
   echo "Creating Machine $VM..."
   $DOCKER_MACHINE rm -f $VM &> /dev/null
   rm -rf ~/.docker/machine/machines/$VM
-  $DOCKER_MACHINE create -d virtualbox --virtualbox-memory 2048 $VM
+  $DOCKER_MACHINE create -d virtualbox --virtualbox-memory --virtualbox-disk-size 1048576 2048 $VM
 else
   echo "Machine $VM already exists in VirtualBox."
 fi

--- a/osx/mpkg/quickstart.app/Contents/Resources/Scripts/start.sh
+++ b/osx/mpkg/quickstart.app/Contents/Resources/Scripts/start.sh
@@ -25,7 +25,7 @@ if [ $VM_EXISTS_CODE -eq 1 ]; then
   echo "Creating Machine $VM..."
   $DOCKER_MACHINE rm -f $VM &> /dev/null
   rm -rf ~/.docker/machine/machines/$VM
-  $DOCKER_MACHINE create -d virtualbox --virtualbox-memory 2048 --virtualbox-disk-size 256000 $VM
+  $DOCKER_MACHINE create -d virtualbox --virtualbox-memory 2048 --virtualbox-disk-size 204800 $VM
 else
   echo "Machine $VM already exists in VirtualBox."
 fi

--- a/osx/mpkg/quickstart.app/Contents/Resources/Scripts/start.sh
+++ b/osx/mpkg/quickstart.app/Contents/Resources/Scripts/start.sh
@@ -25,7 +25,7 @@ if [ $VM_EXISTS_CODE -eq 1 ]; then
   echo "Creating Machine $VM..."
   $DOCKER_MACHINE rm -f $VM &> /dev/null
   rm -rf ~/.docker/machine/machines/$VM
-  $DOCKER_MACHINE create -d virtualbox --virtualbox-memory --virtualbox-disk-size 1048576 2048 $VM
+  $DOCKER_MACHINE create -d virtualbox --virtualbox-memory 2048 --virtualbox-disk-size 1048576 $VM
 else
   echo "Machine $VM already exists in VirtualBox."
 fi

--- a/windows/start.sh
+++ b/windows/start.sh
@@ -24,7 +24,7 @@ if [ $VM_EXISTS_CODE -eq 1 ]; then
   echo "Creating Machine $VM..."
   $DOCKER_MACHINE rm -f $VM &> /dev/null || :
   rm -rf ~/.docker/machine/machines/$VM
-  $DOCKER_MACHINE create -d virtualbox --virtualbox-memory 2048 --virtualbox-disk-size 1048576 $VM
+  $DOCKER_MACHINE create -d virtualbox --virtualbox-memory 2048 --virtualbox-disk-size 256000 $VM
 else
   echo "Machine $VM already exists in VirtualBox."
 fi

--- a/windows/start.sh
+++ b/windows/start.sh
@@ -24,7 +24,7 @@ if [ $VM_EXISTS_CODE -eq 1 ]; then
   echo "Creating Machine $VM..."
   $DOCKER_MACHINE rm -f $VM &> /dev/null || :
   rm -rf ~/.docker/machine/machines/$VM
-  $DOCKER_MACHINE create -d virtualbox --virtualbox-memory 2048 $VM
+  $DOCKER_MACHINE create -d virtualbox --virtualbox-memory 2048 --virtualbox-disk-size 1048576 $VM
 else
   echo "Machine $VM already exists in VirtualBox."
 fi

--- a/windows/start.sh
+++ b/windows/start.sh
@@ -24,7 +24,7 @@ if [ $VM_EXISTS_CODE -eq 1 ]; then
   echo "Creating Machine $VM..."
   $DOCKER_MACHINE rm -f $VM &> /dev/null || :
   rm -rf ~/.docker/machine/machines/$VM
-  $DOCKER_MACHINE create -d virtualbox --virtualbox-memory 2048 --virtualbox-disk-size 256000 $VM
+  $DOCKER_MACHINE create -d virtualbox --virtualbox-memory 2048 --virtualbox-disk-size 204800 $VM
 else
   echo "Machine $VM already exists in VirtualBox."
 fi


### PR DESCRIPTION
I had the same problem commented in issue #157, that issue is marked as closed, but I think that it's still an issue, because, although it can be manually fixed afterwards, it can be quite disappointing to have to manually create a new docker-machine and set a bigger disk size to keep using Docker, having to re-build everything from scratch.

I think the default shouldn't be only 20 GB of disk, knowing that VirtualBox creates a dynamic disk size, it only takes as much (real) space as it is needing (starts with just 200 MB), limited by a maximum of the specified disk size.

In my case, after having several images built and working I got my VM disk space full, and having to re-build every image (in a new, modified docker-machine) with a not-so-speedy connection is sort of painful.

Also, I think that the idea of the Toolbox is to facilitate using Docker, specially for new users, not requiring them to understand and use docker-machine from the beginning.

In this Pull Request I'm increasing the default size of the default machine to 1 TB (I manually created a new docker-machine with that size and it worked. I got some errors when I tried with 2 TB).

As I said, VirtualBox will start with only what it needs (200 MB) but the Virtual Machine will think that it has 1 TB to use and won't stop working just because of the initially declared disk size is full.
