### PR TITLE
#203 - Start default machine with dynamic disk size of max 1 TB instead of 2 GB

### DIFF
--- a/osx/mpkg/quickstart.app/Contents/Resources/Scripts/start.sh
+++ b/osx/mpkg/quickstart.app/Contents/Resources/Scripts/start.sh
@@ -25,7 +25,7 @@ if [ $VM_EXISTS_CODE -eq 1 ]; then
   echo "Creating Machine $VM..."
   $DOCKER_MACHINE rm -f $VM &> /dev/null
   rm -rf ~/.docker/machine/machines/$VM
-  $DOCKER_MACHINE create -d virtualbox --virtualbox-memory 2048 $VM
+  $DOCKER_MACHINE create -d virtualbox --virtualbox-memory 2048 --virtualbox-disk-size 1048576 $VM
 else
   echo "Machine $VM already exists in VirtualBox."
 fi


### PR DESCRIPTION
 - Start default machine with dynamic disk size of max 1 TB instead of 2 GB