### PR TITLE
Only select one shell

### DIFF
--- a/osx/mpkg/quickstart.app/Contents/Resources/Scripts/start.sh
+++ b/osx/mpkg/quickstart.app/Contents/Resources/Scripts/start.sh
@@ -56,7 +56,7 @@ echo
 
 eval $($DOCKER_MACHINE env $VM --shell=bash)
 
-USER_SHELL=$(dscl /Search -read /Users/$USER UserShell | awk '{print $2}')
+USER_SHELL=$(dscl /Search -read /Users/$USER UserShell | awk '{print $2}' | head -n 1)
 if [ "$USER_SHELL" = "/bin/bash" ] || [ "$USER_SHELL" = "/bin/zsh" ] || [ "$USER_SHELL" = "/bin/sh" ]; then
   $USER_SHELL --login
 else


### PR DESCRIPTION
`dscl /Search -read /Users/$USER UserShell | awk '{print $2}'` can output multiple user shells. For me, I have both `/bin/zsh` and `/bin/bash` on two separated line. Then the `USER_SHELL` should become `/bin/zsh /bin/bash`.

```bash
$echo $(dscl /Search -read /Users/$USER UserShell | awk '{print $2}')            
> /bin/zsh /bin/bash
```

which can lead to fatal error when you are calling `$USER_SHELL`. Because you will be calling `/bin/zsh` with first parameter as `/bin/bash`.

See #210 for details.