### PR TITLE
Fix tty errors using winpty

### DIFF
--- a/windows/start.sh
+++ b/windows/start.sh
@@ -31,4 +31,32 @@ fi
 
 echo "Starting machine $VM..."
 $DOCKER_MACHINE start $VM
-$DOCKER_MACHINE ssh $VM
+
+echo "Setting environment variables for machine $VM..."
+eval "$($DOCKER_MACHINE env --shell=bash $VM)"
+
+clear
+cat << EOF
+
+
+                        ##         .
+                  ## ## ##        ==
+               ## ## ## ## ##    ===
+           /"""""""""""""""""\___/ ===
+      ~~~ {~~ ~~~~ ~~~ ~~~~ ~~~ ~ /  ===- ~~~
+           \______ o           __/
+             \    \         __/
+              \____\_______/
+
+EOF
+echo -e "${BLUE}docker${NC} is configured to use the ${GREEN}$VM${NC} machine with IP ${GREEN}$($DOCKER_MACHINE ip $VM)${NC}"
+echo "For help getting started, check out the docs at https://docs.docker.com"
+echo
+cd
+
+docker () {
+  winpty docker $@
+}
+export -f docker
+
+exec "$BASH" --login -i


### PR DESCRIPTION
Fixes #183 and #220. Creates an alias for docker that uses winpty when using the Docker Quickstart Terminal.

Credit for fix: @gmanfunky. Thank you!

cc @nathanleclaire @mchiang0610. What are your thoughts?

Interestingly enough, this also works for `docker-compose` @aanand @dnephin 