### PR TITLE
Fix OSX bug where multiple UserShell records break start.sh

### DIFF
--- a/osx/mpkg/quickstart.app/Contents/Resources/Scripts/start.sh
+++ b/osx/mpkg/quickstart.app/Contents/Resources/Scripts/start.sh
@@ -56,7 +56,7 @@ echo
 
 eval $($DOCKER_MACHINE env $VM --shell=bash)
 
-USER_SHELL=$(dscl /Search -read /Users/$USER UserShell | awk '{print $2}')
+USER_SHELL=$(dscl /Search -read /Users/$USER UserShell | head -n 1 | awk '{print $2}')
 if [ "$USER_SHELL" = "/bin/bash" ] || [ "$USER_SHELL" = "/bin/zsh" ] || [ "$USER_SHELL" = "/bin/sh" ]; then
   $USER_SHELL --login
 else


### PR DESCRIPTION
# Background
When executing Docker Quickstart Terminal.app on my MacBook, it results in the following error:
```
docker is configured to use the default machine with IP 192.168.99.100
For help getting started, check out the docs at https://docs.docker.com

/bin/bash: /bin/bash: cannot execute binary file
```

It appears that my user account has multiple UserShell keys defined in the Directory Service:
```
~> dscl /Search -read /Users/$USER UserShell | awk '{print $2}'
/bin/bash
/bin/bash
```
The start.sh script tries to execute the entire string of "/bin/bash /bin/bash", resulting in the error.

# Suggested Fix
Line 59 of the start.sh script does not handle the case of multiple UserShell entries, resulting in it trying to execute a command of `/bin/bash /bin/bash`. By using `head -n1` to limit the results of `dscl`, only a single `/bin/bash` will be executed (the desired behavior).