### PR TITLE
Changes to create an Installer binary for Windows 32-bit OS

### DIFF
--- a/Dockerfile.win32
+++ b/Dockerfile.win32
@@ -1,0 +1,52 @@
+FROM debian:jessie
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN dpkg --add-architecture i386
+RUN sed -i "s/main/main contrib non-free/" etc/apt/sources.list
+RUN apt-get update && apt-get install -yq wine curl unrar unzip
+
+# innosetup
+RUN mkdir innosetup && \
+    cd innosetup && \
+    curl -fsSL -o innounp043.rar "https://downloads.sourceforge.net/project/innounp/innounp/innounp%200.43/innounp043.rar?r=&ts=1439566551&use_mirror=skylineservers" && \
+    unrar e innounp043.rar
+
+RUN cd innosetup && \
+    curl -fsSL -o is-unicode.exe http://www.jrsoftware.org/download.php/is-unicode.exe && \
+    wine "./innounp.exe" -e "is-unicode.exe"
+
+# installer components
+ENV INSTALLER_VERSION 1.8.2d
+ENV DOCKER_VERSION 1.8.2
+ENV DOCKER_MACHINE_VERSION 0.4.1
+ENV BOOT2DOCKER_ISO_VERSION $DOCKER_VERSION
+ENV KITEMATIC_VERSION 0.8.6
+ENV VIRTUALBOX_VERSION 5.0.6
+ENV VIRTUALBOX_REVISION 103037
+ENV GIT_VERSION 2.5.0
+ENV MIXPANEL_TOKEN c306ae65c33d7d09fe3e546f36493a6e
+
+RUN mkdir /bundle
+WORKDIR /bundle
+RUN curl -fsSL -o docker.exe "https://get.docker.com/builds/Windows/i386/docker-$DOCKER_VERSION.exe"
+RUN curl -fsSL -o docker-machine.exe "https://github.com/docker/machine/releases/download/v$DOCKER_MACHINE_VERSION/docker-machine_windows-386.exe"
+RUN curl -fsSL -o boot2docker.iso https://github.com/boot2docker/boot2docker/releases/download/v$BOOT2DOCKER_ISO_VERSION/boot2docker.iso
+RUN curl -fsSL -o kitematic.zip "https://github.com/kitematic/kitematic/releases/download/v$KITEMATIC_VERSION/Kitematic-$KITEMATIC_VERSION-Windows-Alpha.zip" && \
+    mkdir kitematic && \
+    cd kitematic && \
+    unzip ../kitematic.zip && \
+    rm ../kitematic.zip
+RUN curl -fsSL -o Git.exe "https://github.com/git-for-windows/git/releases/download/v$GIT_VERSION.windows.1/Git-$GIT_VERSION-32-bit.exe"
+RUN curl -fsSL -o virtualbox.exe "http://download.virtualbox.org/virtualbox/$VIRTUALBOX_VERSION/VirtualBox-$VIRTUALBOX_VERSION-$VIRTUALBOX_REVISION-Win.exe"
+RUN wine virtualbox.exe -extract -silent -path . && \
+	  rm virtualbox.exe && \
+	  rm *amd64.msi && \
+	  mv *_x86.msi VirtualBox_x86.msi
+
+# Add installer resources
+COPY windows /installer
+
+WORKDIR /installer
+RUN rm -rf /tmp/.wine-0/
+RUN wine ../innosetup/ISCC.exe Toolbox32.iss /DMyAppVersion=$INSTALLER_VERSION /DMixpanelToken=$MIXPANEL_TOKEN

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ DOCKER_OSX_CONTAINER := build-osx-installer
 DOCKER_WINDOWS_CONTAINER := build-windows-installer
 SIGNING_SERVER := $(signing_server)
 
-default: osx windows
+default: osx windows win32
 	@true
 
 osx: clean-osx
@@ -21,10 +21,21 @@ windows: clean-windows
 	docker cp "$(DOCKER_WINDOWS_CONTAINER)":/installer/Output/DockerToolbox.exe dist/
 	docker rm "$(DOCKER_WINDOWS_CONTAINER)" 2>/dev/null || true
 
+win32: clean-win32
+	docker build -t $(DOCKER_WINDOWS_IMAGE) -f Dockerfile.win32 .
+	docker run --name "$(DOCKER_WINDOWS_CONTAINER)" "$(DOCKER_WINDOWS_IMAGE)"
+	mkdir -p dist
+	docker cp "$(DOCKER_WINDOWS_CONTAINER)":/installer/Output/DockerToolbox.exe dist/DockerToolbox_x86.exe
+	docker rm "$(DOCKER_WINDOWS_CONTAINER)" 2>/dev/null || true
+
 clean-osx:
 	rm -f DockerToolbox-*.pkg
 	docker rm "$(DOCKER_OSX_CONTAINER)" 2>/dev/null || true
 
 clean-windows:
+	rm -f DockerToolbox-*.exe
+	docker rm "$(DOCKER_WINDOWS_CONTAINER)" 2>/dev/null || true
+
+clean-win32:
 	rm -f DockerToolbox-*.exe
 	docker rm "$(DOCKER_WINDOWS_CONTAINER)" 2>/dev/null || true

--- a/windows/Toolbox32.iss
+++ b/windows/Toolbox32.iss
@@ -1,0 +1,386 @@
+#define MyAppName "Docker Toolbox"
+#define MyAppPublisher "Docker"
+#define MyAppURL "https://docker.com"
+#define MyAppContact "https://docs.docker.com"
+
+#define b2dIsoPath "..\bundle\boot2docker.iso"
+#define dockerCli "..\bundle\docker.exe"
+#define dockerMachineCli "..\bundle\docker-machine.exe"
+#define kitematic "..\bundle\kitematic"
+#define git "..\bundle\Git.exe"
+#define virtualBoxCommon "..\bundle\common.cab"
+#define virtualBoxMsi "..\bundle\VirtualBox_x86.msi"
+
+[Setup]
+AppCopyright={#MyAppPublisher}
+AppId={{FC4417F0-D7F3-48DB-BCE1-F5ED5BAFFD91}
+AppContact={#MyAppContact}
+AppComments={#MyAppURL}
+AppName={#MyAppName}
+AppVersion={#MyAppVersion}
+AppPublisher={#MyAppPublisher}
+AppPublisherURL={#MyAppURL}
+AppSupportURL={#MyAppURL}
+AppUpdatesURL={#MyAppURL}
+ArchitecturesAllowed=x86
+ArchitecturesInstallIn64BitMode=
+DefaultDirName={pf}\{#MyAppName}
+DefaultGroupName=Docker
+DisableProgramGroupPage=yes
+OutputBaseFilename=DockerToolbox
+Compression=lzma
+SolidCompression=yes
+WizardImageFile=windows-installer-side.bmp
+WizardSmallImageFile=windows-installer-logo.bmp
+WizardImageStretch=no
+WizardImageBackColor=$22EBB8
+UninstallDisplayIcon={app}\unins000.exe
+SetupIconFile=toolbox.ico
+ChangesEnvironment=true
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Types]
+Name: "full"; Description: "Full installation"
+Name: "custom"; Description: "Custom installation"; Flags: iscustom
+
+[Run]
+Filename: "{win}\explorer.exe"; Parameters: "{userprograms}\Docker\"; Flags: postinstall skipifsilent; Description: "View Shortcuts in File Explorer"
+
+[Tasks]
+Name: desktopicon; Description: "{cm:CreateDesktopIcon}"
+Name: modifypath; Description: "Add docker.exe & docker-machine.exe to &PATH"
+
+[Components]
+Name: "Docker"; Description: "Docker Client for Windows" ; Types: full custom; Flags: fixed
+Name: "DockerMachine"; Description: "Docker Machine for Windows" ; Types: full custom; Flags: fixed
+Name: "VirtualBox"; Description: "VirtualBox"; Types: full custom; Flags: disablenouninstallwarning
+Name: "Kitematic"; Description: "Kitematic for Windows (Alpha)" ; Types: full custom
+Name: "Git"; Description: "Git for Windows"; Types: full custom; Flags: disablenouninstallwarning
+
+[Files]
+Source: ".\docker-quickstart-terminal.ico"; DestDir: "{app}"; Flags: ignoreversion
+Source: "{#dockerCli}"; DestDir: "{app}"; Flags: ignoreversion; Components: "Docker"
+Source: ".\start.sh"; DestDir: "{app}"; Flags: ignoreversion; Components: "Docker"
+Source: ".\delete.sh"; DestDir: "{app}"; Flags: ignoreversion; Components: "Docker"
+Source: "{#dockerMachineCli}"; DestDir: "{app}"; Flags: ignoreversion; Components: "DockerMachine"
+Source: ".\migrate.sh"; DestDir: "{app}"; Flags: ignoreversion; Components: "DockerMachine"
+Source: ".\migrate.bat"; DestDir: "{app}"; Flags: ignoreversion; Components: "DockerMachine"
+Source: "{#kitematic}\*"; DestDir: "{app}\kitematic"; Flags: ignoreversion recursesubdirs; Components: "Kitematic"
+Source: "{#b2dIsoPath}"; DestDir: "{app}"; Flags: ignoreversion; Components: "DockerMachine"; AfterInstall: CopyBoot2DockerISO()
+Source: "{#git}"; DestDir: "{app}\installers\git"; DestName: "git.exe"; AfterInstall: RunInstallGit();  Components: "Git"
+Source: "{#virtualBoxCommon}"; DestDir: "{app}\installers\virtualbox"; Components: "VirtualBox"
+Source: "{#virtualBoxMsi}"; DestDir: "{app}\installers\virtualbox"; DestName: "virtualbox.msi"; AfterInstall: RunInstallVirtualBox(); Components: "VirtualBox"
+
+[Icons]
+Name: "{userprograms}\Docker\Kitematic (Alpha)"; WorkingDir: "{app}"; Filename: "{app}\kitematic\Kitematic.exe"; Components: "Kitematic"
+Name: "{commondesktop}\Kitematic (Alpha)"; WorkingDir: "{app}"; Filename: "{app}\kitematic\Kitematic.exe"; Tasks: desktopicon; Components: "Kitematic"
+Name: "{userprograms}\Docker\Docker Quickstart Terminal"; WorkingDir: "{app}"; Filename: "{pf}\Git\git-bash.exe"; Parameters: """{app}\start.sh"""; IconFilename: "{app}/docker-quickstart-terminal.ico"; Components: "Docker"
+Name: "{commondesktop}\Docker Quickstart Terminal"; WorkingDir: "{app}"; Filename: "{pf}\Git\git-bash.exe"; Parameters: """{app}\start.sh"""; IconFilename: "{app}/docker-quickstart-terminal.ico"; Tasks: desktopicon; Components: "Docker"
+
+[UninstallRun]
+Filename: "{app}\delete.sh"
+
+[UninstallDelete]
+Type: filesandordirs; Name: "{localappdata}\..\Roaming\Kitematic"
+
+[Code]
+#include "base64.iss"
+#include "guid.iss"
+
+var
+	restart: boolean;
+  TrackingDisabled: Boolean;
+	DockerInstallDocs: TLabel;
+  TrackingCheckBox: TNewCheckBox;
+
+function uuid(): String;
+var
+  dirpath: String;
+  filepath: String;
+  ansiresult: AnsiString;
+begin
+  dirpath := ExpandConstant('{userappdata}\DockerToolbox');
+  filepath := dirpath + '\id.txt';
+  ForceDirectories(dirpath);
+
+  Result := '';
+  if FileExists(filepath) then
+    LoadStringFromFile(filepath, ansiresult);
+    Result := String(ansiresult)
+
+  if Length(Result) = 0 then
+    Result := GetGuid('');
+    StringChangeEx(Result, '{', '', True);
+    StringChangeEx(Result, '}', '', True);
+    SaveStringToFile(filepath, AnsiString(Result), False);
+end;
+
+function WindowsVersionString(): String;
+var
+	ResultCode: Integer;
+	lines : TArrayOfString;
+begin
+	if not Exec(ExpandConstant('{cmd}'), ExpandConstant('/c wmic os get caption | more +1 > C:\windows-version.txt'), '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then begin
+		Result := 'N/A';
+		exit;
+	end;
+
+	if LoadStringsFromFile(ExpandConstant('C:\windows-version.txt'), lines) then begin
+		Result := lines[0];
+	end else begin
+		Result := 'N/A'
+	end;
+end;
+
+procedure TrackEvent(name: String);
+var
+  payload: String;
+  WinHttpReq: Variant;
+begin
+  if TrackingDisabled or WizardSilent() then
+    exit;
+  try
+    payload := Encode64(Format(ExpandConstant('{{"event": "%s", "properties": {{"token": "{#MixpanelToken}", "distinct_id": "%s", "os": "win32", "os version": "%s", "version": "{#MyAppVersion}"}}'), [name, uuid(), WindowsVersionString()]));
+    WinHttpReq := CreateOleObject('WinHttp.WinHttpRequest.5.1');
+    WinHttpReq.Open('POST', 'https://api.mixpanel.com/track/?data=' + payload, false);
+    WinHttpReq.SetRequestHeader('Content-Type', 'application/json');
+    WinHttpReq.Send('');
+  except
+  end;
+end;
+
+function NeedRestart(): Boolean;
+begin
+	Result := restart;
+end;
+
+function NeedToInstallVirtualBox(): Boolean;
+begin
+	// TODO: Also compare versions
+	Result := (
+		(GetEnv('VBOX_INSTALL_PATH') = '')
+		and
+		(GetEnv('VBOX_MSI_INSTALL_PATH') = '')
+	);
+end;
+
+function NeedToInstallGit(): Boolean;
+begin
+	// TODO: Find a better way to see if Git is installed
+	Result := not DirExists('C:\Program Files\Git') or not FileExists('C:\Program Files\Git\git-bash.exe')
+end;
+
+procedure DocLinkClick(Sender: TObject);
+var
+	ErrorCode: Integer;
+begin
+	ShellExec('', 'https://docs.docker.com/installation/windows/', '', '', SW_SHOW, ewNoWait, ErrorCode);
+end;
+
+procedure TrackingCheckBoxClicked(Sender: TObject);
+begin
+  if TrackingCheckBox.Checked then begin
+		TrackingDisabled := False;
+    TrackEvent('Enabled Tracking');
+  end else begin
+    TrackEvent('Disabled Tracking');
+    TrackingDisabled := True;
+  end;
+end;
+
+procedure InitializeWizard;
+var
+  WelcomePage: TWizardPage;
+	TrackingLabel: TLabel;
+begin
+	DockerInstallDocs := TLabel.Create(WizardForm);
+	DockerInstallDocs.Parent := WizardForm;
+	DockerInstallDocs.Left := 8;
+	DockerInstallDocs.Top := WizardForm.ClientHeight - DockerInstallDocs.ClientHeight - 8;
+	DockerInstallDocs.Cursor := crHand;
+	DockerInstallDocs.Font.Color := clBlue;
+	DockerInstallDocs.Font.Style := [fsUnderline];
+	DockerInstallDocs.Caption := '{#MyAppName} installation documentation';
+	DockerInstallDocs.OnClick := @DocLinkClick;
+	DockerInstallDocs.Visible := True;
+
+  WelcomePage := PageFromID(wpWelcome)
+
+	WizardForm.WelcomeLabel2.AutoSize := True;
+
+  TrackingCheckBox := TNewCheckBox.Create(WizardForm);
+  TrackingCheckBox.Top := 168;
+  TrackingCheckBox.Left := WizardForm.WelcomeLabel2.Left;
+  TrackingCheckBox.Width := WizardForm.WelcomeLabel2.Width;
+  TrackingCheckBox.Height := 40;
+  TrackingCheckBox.Caption := 'Send one-time, anonymous diagnostics during install.';
+  TrackingCheckBox.Checked := True;
+  TrackingCheckBox.Parent := WelcomePage.Surface;
+  TrackingCheckBox.OnClick := @TrackingCheckboxClicked;
+
+	TrackingLabel := TLabel.Create(WizardForm);
+	TrackingLabel.Parent := WelcomePage.Surface;
+	TrackingLabel.Font := WizardForm.WelcomeLabel2.Font;
+	TrackingLabel.Font.Color := clGray;
+  TrackingLabel.Caption := 'This data helps us detect problems and improve the installation experience. We only use it for aggregate statistics and will never share it with third parties.';
+	TrackingLabel.WordWrap := True;
+	TrackingLabel.Visible := True;
+	TrackingLabel.Left := WizardForm.WelcomeLabel2.Left;
+	TrackingLabel.Width := WizardForm.WelcomeLabel2.Width;
+	TrackingLabel.Top := 200;
+	TrackingLabel.Height := 100;
+
+	WizardForm.FinishedLabel.AutoSize := True;
+	WizardForm.FinishedLabel.Caption :=
+		'{#MyAppName} installation completed.' + \
+		#13#10 + \
+		#13#10 + \
+		'Run using the `Docker Quickstart Terminal` icon on your desktop or in [Program Files] - then start a test container with:' + \
+		#13#10 + \
+		'         `docker run hello-world`' + \
+		#13#10 + \
+		#13#10 + \
+		// TODO: it seems making hyperlinks is hard :/
+		//'To save and share container images, automate workflows, and more sign-up for a free <a href="http://hub.docker.com/?utm_source=b2d&utm_medium=installer&utm_term=summary&utm_content=windows&utm_campaign=product">Docker Hub account</a>.' + \
+		#13#10 + \
+		#13#10 +
+		'You can upgrade your existing Docker Machine dev VM without data loss by running:' + \
+		#13#10 + \
+		'         `docker-machine upgrade dev`' + \
+		#13#10 + \
+		#13#10 + \
+		'For further information, please see the {#MyAppName} installation documentation link.'
+
+		// Don't do this until we can compare versions
+		// Wizardform.ComponentsList.Checked[2] := NeedToInstallVirtualBox();
+		Wizardform.ComponentsList.ItemEnabled[2] := not NeedToInstallVirtualBox();
+		Wizardform.ComponentsList.Checked[4] := NeedToInstallGit();
+		Wizardform.ComponentsList.ItemEnabled[4] := not NeedToInstallGit();
+end;
+
+function InitializeSetup(): boolean;
+begin
+  TrackEvent('Installer Started');
+  Result := True;
+end;
+
+function NextButtonClick(CurPageID: Integer): Boolean;
+begin
+  if CurPageID = wpWelcome then begin
+      TrackEvent('Continued from Overview');
+  end;
+  Result := True
+end;
+
+procedure RunInstallVirtualBox();
+var
+	ResultCode: Integer;
+begin
+	WizardForm.FilenameLabel.Caption := 'installing VirtualBox'
+	if not Exec(ExpandConstant('msiexec'), ExpandConstant('/qn /i "{app}\installers\virtualbox\virtualbox.msi" /norestart'), '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+		MsgBox('virtualbox install failure', mbInformation, MB_OK);
+end;
+
+procedure RunInstallGit();
+var
+	ResultCode: Integer;
+begin
+	WizardForm.FilenameLabel.Caption := 'installing Git for Windows'
+	if Exec(ExpandConstant('{app}\installers\git\git.exe'), '/sp- /verysilent /norestart', '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+	begin
+		// handle success if necessary; ResultCode contains the exit code
+		//MsgBox('git installed OK', mbInformation, MB_OK);
+	end
+	else begin
+		// handle failure if necessary; ResultCode contains the error code
+		MsgBox('git install failure', mbInformation, MB_OK);
+	end;
+end;
+
+procedure CopyBoot2DockerISO();
+begin
+  WizardForm.FilenameLabel.Caption := 'copying boot2docker iso'
+  if not ForceDirectories(ExpandConstant('{userdocs}\..\.docker\machine\cache')) then
+      MsgBox('Failed to create docker machine cache dir', mbError, MB_OK);
+  if not FileCopy(ExpandConstant('{app}\boot2docker.iso'), ExpandConstant('{userdocs}\..\.docker\machine\cache\boot2docker.iso'), false) then
+      MsgBox('File moving failed!', mbError, MB_OK);
+end;
+
+function MigrateVM() : Boolean;
+var
+  ResultCode: Integer;
+begin
+  if NeedToInstallGit() or NeedToInstallVirtualBox() or not FileExists(ExpandConstant('{app}\docker-machine.exe')) then begin
+    Result := true
+    exit
+  end;
+
+  ExecAsOriginalUser('C:\Program Files\Oracle\VirtualBox\VBoxManage.exe', 'showvminfo default', '', SW_HIDE, ewWaitUntilTerminated, ResultCode)
+  if ResultCode <> 1 then begin
+    Result := true
+    exit
+  end;
+
+  ExecAsOriginalUser('C:\Program Files\Oracle\VirtualBox\VBoxManage.exe', 'showvminfo boot2docker-vm', '', SW_HIDE, ewWaitUntilTerminated, ResultCode)
+  if ResultCode <> 0 then begin
+    Result := true
+    exit
+  end;
+
+  if MsgBox('Migrate your existing Boot2Docker VM to work with the Docker Toolbox? Your existing Boot2Docker VM will not be affected. This should take about a minute.', mbConfirmation, MB_YESNO) = IDYES then
+  begin
+		TrackEvent('Boot2Docker Migration Started');
+    WizardForm.StatusLabel.Caption := 'Migrating Boot2Docker VM...'
+    WizardForm.FilenameLabel.Caption := 'This will take a minute...'
+    ExecAsOriginalUser(ExpandConstant('{app}\docker-machine.exe'), ExpandConstant('rm -f default > nul 2>&1'), '', SW_HIDE, ewWaitUntilTerminated, ResultCode)
+    DelTree(ExpandConstant('{userdocs}\..\.docker\machine\machines\default'), True, True, True);
+    ExecAsOriginalUser(ExpandConstant('{app}\migrate.bat'), ExpandConstant('> {localappdata}\Temp\toolbox-migration-logs.txt 2>&1'), '', SW_HIDE, ewWaitUntilTerminated, ResultCode)
+    if ResultCode = 0 then
+    begin
+      TrackEvent('Boot2Docker Migration Succeeded');
+      MsgBox('Succcessfully migrated Boot2Docker VM to a Docker Machine VM named "default"', mbInformation, MB_OK);
+    end
+    else begin
+      TrackEvent('Boot2Docker Migration Failed');
+      MsgBox('Migration of Boot2Docker VM failed. Please file an issue with the migration logs at https://github.com/docker/toolbox/issues/new.', mbCriticalError, MB_OK);
+      Exec(ExpandConstant('{win}\notepad.exe'), ExpandConstant('{localappdata}\Temp\toolbox-migration-logs.txt'), '', SW_SHOW, ewNoWait, ResultCode)
+      Result := false
+			WizardForm.Close;
+      exit;
+    end;
+  end
+  else
+  begin
+    TrackEvent('Boot2Docker Migration Skipped');
+  end;
+  Result := true
+end;
+
+const
+	ModPathName = 'modifypath';
+	ModPathType = 'user';
+
+function ModPathDir(): TArrayOfString;
+begin
+	setArrayLength(Result, 1);
+	Result[0] := ExpandConstant('{app}');
+end;
+#include "modpath.iss"
+
+procedure CurStepChanged(CurStep: TSetupStep);
+var
+	Success: Boolean;
+begin
+	Success := True;
+	if CurStep = ssPostInstall then
+  begin
+    if IsTaskSelected(ModPathName) then
+			ModPath();
+    if not WizardSilent() then
+      Success := MigrateVM();
+		if Success then
+			trackEvent('Installer Finished');
+  end;
+end;


### PR DESCRIPTION
Changes to create an Installer binary for Windows 32-bit OS, that has support for VT-x CPU. I work with a team, that has several 32-bit Windows 7 OS, where I need Docker installed.

Run 'make win32' to create a 32-bit Windows Toolbox binary

The changes are minimal:

* Changed Windows Dockerfile to point to 32-bit binaries (new file Dockerfile.win32)
* Changed Toolbox.iss to indicate 32-bit architecture and replace {pf64} with {pf} (new file Toolbox32.iss)
* Modified Makefile to include win32 as a new target