### PR TITLE
Use alias instead of exported function for `winpty` docker tty fix

### DIFF
--- a/windows/start.sh
+++ b/windows/start.sh
@@ -54,4 +54,13 @@ echo "For help getting started, check out the docs at https://docs.docker.com"
 echo
 cd
 
-bash --rcfile <(echo 'alias docker="winpty docker"') -i
+docker () {
+  if [ -t 1 ] && [ -t 0 ]; then
+    winpty docker.exe $@
+  else
+    docker.exe $@
+  fi
+}
+export -f docker
+
+exec "$BASH" --login -i

--- a/windows/start.sh
+++ b/windows/start.sh
@@ -54,9 +54,4 @@ echo "For help getting started, check out the docs at https://docs.docker.com"
 echo
 cd
 
-docker () {
-  winpty docker $@
-}
-export -f docker
-
-exec "$BASH" --login -i
+bash --rcfile <(echo 'alias docker="winpty docker"') -i


### PR DESCRIPTION
@gmanfunky, what do you think?

- `docker run -it nginx bash` works
- Running a script from this terminal will not export the alias, thus the script will work as usual