### PR TITLE
Verify boot2docker VM is not running before starting it

### DIFF
--- a/osx/mpkg/quickstart.app/Contents/Resources/Scripts/start.sh
+++ b/osx/mpkg/quickstart.app/Contents/Resources/Scripts/start.sh
@@ -30,8 +30,11 @@ else
   echo "Machine $VM already exists in VirtualBox."
 fi
 
-echo "Starting machine $VM..."
-$DOCKER_MACHINE start $VM
+VM_STATUS=$($DOCKER_MACHINE status $VM)
+if [ "$VM_STATUS" != "Running" ]; then
+  echo "Starting machine $VM..."
+  $DOCKER_MACHINE start $VM
+fi
 
 echo "Setting environment variables for machine $VM..."
 clear

--- a/windows/start.sh
+++ b/windows/start.sh
@@ -34,8 +34,11 @@ else
   echo "Machine $VM already exists in VirtualBox."
 fi
 
-echo "Starting machine $VM..."
-$DOCKER_MACHINE start $VM
+VM_STATUS=$($DOCKER_MACHINE status $VM)
+if [ "$VM_STATUS" != "Running" ]; then
+  echo "Starting machine $VM..."
+  $DOCKER_MACHINE start $VM
+fi
 
 echo "Setting environment variables for machine $VM..."
 eval "$($DOCKER_MACHINE env --shell=bash $VM)"


### PR DESCRIPTION
Docker-machine now seems to throw an error when starting a running VM, which causes start.sh to fail with a rather unhelpful message.  Checking to see what the status of the VM is before we start it prevents this error.