### PR TITLE
Unmounting /Users in the docker-machine, replacing it with a dynamic …

### DIFF
--- a/osx/mpkg/quickstart.app/Contents/Resources/Scripts/start.sh
+++ b/osx/mpkg/quickstart.app/Contents/Resources/Scripts/start.sh
@@ -37,6 +37,11 @@ if [ "$VM_STATUS" != "Running" ]; then
   yes | $DOCKER_MACHINE regenerate-certs $VM
 fi
 
+echo "Replacing VBoxfs mounts with NFS"
+echo /Users -mapall=$(whoami):staff $HOSTNAME | sudo tee /etc/exports
+sudo nfsd restart
+$DOCKER_MACHINE ssh $VM "sudo umount /Users; sudo /usr/local/etc/init.d/nfs-client restart; sudo mount $HOSTNAME:/Users /Users -o rw,async,noatime,rsize=32768,wsize=32768,proto=tcp;"
+
 echo "Setting environment variables for machine $VM..."
 clear
 

--- a/osx/mpkg/quickstart.app/Contents/Resources/Scripts/start.sh
+++ b/osx/mpkg/quickstart.app/Contents/Resources/Scripts/start.sh
@@ -38,9 +38,12 @@ if [ "$VM_STATUS" != "Running" ]; then
 fi
 
 echo "Replacing VBoxfs mounts with NFS"
+if test -f "/etc/nfs.conf"; then sudo sed -i '' '/nfs.server.mount.require_resv_port/d' /etc/nfs.conf; fi
 if test -f "/etc/exports"; then sudo sed -i '' '/Users/d' /etc/exports; fi
+echo 'nfs.server.mount.require_resv_port = 0' | sudo tee -a /etc/nfs.conf > /dev/null
 echo /Users -mapall=$(whoami):staff $HOSTNAME | sudo tee -a /etc/exports > /dev/null
-sudo nfsd start
+sudo nfsd restart
+
 $DOCKER_MACHINE ssh $VM "sudo umount /Users; sudo /usr/local/etc/init.d/nfs-client restart; sudo mount $HOSTNAME:/Users /Users -o rw,async,noatime,rsize=32768,wsize=32768,proto=tcp;"
 
 echo "Setting environment variables for machine $VM..."

--- a/osx/mpkg/quickstart.app/Contents/Resources/Scripts/start.sh
+++ b/osx/mpkg/quickstart.app/Contents/Resources/Scripts/start.sh
@@ -38,8 +38,9 @@ if [ "$VM_STATUS" != "Running" ]; then
 fi
 
 echo "Replacing VBoxfs mounts with NFS"
-echo /Users -mapall=$(whoami):staff $HOSTNAME | sudo tee /etc/exports
-sudo nfsd restart
+if test -f "/etc/exports"; then sudo sed -i '' '/Users/d' /etc/exports; fi
+echo /Users -mapall=$(whoami):staff $HOSTNAME | sudo tee -a /etc/exports > /dev/null
+sudo nfsd start
 $DOCKER_MACHINE ssh $VM "sudo umount /Users; sudo /usr/local/etc/init.d/nfs-client restart; sudo mount $HOSTNAME:/Users /Users -o rw,async,noatime,rsize=32768,wsize=32768,proto=tcp;"
 
 echo "Setting environment variables for machine $VM..."


### PR DESCRIPTION
As the VBoxfs causes issues when updating files in mounted volumes, I've replaced it with an NFS mount. This makes it useful for development where you update files on your host machine and want to see the changes reflected immediately in a website.

I ran into issues when serving content through NGinx from a volume and updated the files. The changes were reflected locally and in the container, but not in the browser. With the NFS mount this is now solved.

The script uses the hostname and currently logged in user to create the NFS mount and update the /etc/exports file.