### PR TITLE
Use NDIS5 host network filter drivers with VirtualBox

### DIFF
--- a/windows/Toolbox.iss
+++ b/windows/Toolbox.iss
@@ -95,7 +95,6 @@ Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"DOCKER_TOOLBOX_I
 #include "guid.iss"
 
 var
-	restart: boolean;
 	TrackingDisabled: Boolean;
   TrackingCheckBox: TNewCheckBox;
 
@@ -142,7 +141,6 @@ procedure TrackEventWithProperties(name: String; properties: String);
 var
   payload: String;
   WinHttpReq: Variant;
-	tracking: String;
 begin
   if TrackingDisabled or WizardSilent() then
     exit;

--- a/windows/Toolbox.iss
+++ b/windows/Toolbox.iss
@@ -250,7 +250,7 @@ var
 	ResultCode: Integer;
 begin
 	WizardForm.FilenameLabel.Caption := 'installing VirtualBox'
-	if not Exec(ExpandConstant('msiexec'), ExpandConstant('/qn /i "{app}\installers\virtualbox\virtualbox.msi" /norestart'), '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+	if not Exec(ExpandConstant('msiexec'), ExpandConstant('/qn /i "{app}\installers\virtualbox\virtualbox.msi" NETWORKTYPE=NDIS5 /norestart'), '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
 		MsgBox('virtualbox install failure', mbInformation, MB_OK);
 end;
 


### PR DESCRIPTION
    VirtualBox 5.x+ includes both NDIS5 and NDIS6 host network filter drivers.
    NDIS6 is installed by default on Windows Vista and later. NDIS6 breaks
    host-only and bridge interfaces in VirtualBox. Please see the bug report
    below:
    
    https://www.virtualbox.org/ticket/14457
