### PR TITLE
docker machine drivers removal

### DIFF
--- a/osx/uninstall.sh
+++ b/osx/uninstall.sh
@@ -22,6 +22,7 @@ rm -rf /Applications/Docker
 echo "Removing docker binaries..."
 rm -f /usr/local/bin/docker
 rm -f /usr/local/bin/docker-machine
+rm -f /usr/local/bin/docker-machine-driver-*
 rm -f /usr/local/bin/docker-compose
 
 echo "Removing boot2docker.iso"


### PR DESCRIPTION
While uninstalling docker toolbox (and then docker machine), it's cleaner to remove docker machine drivers as well.