### PR TITLE
Ability to switch to different VM providers by config file (OS X only)

### DIFF
--- a/osx/mpkg/quickstart.app/Contents/Resources/Scripts/start.sh
+++ b/osx/mpkg/quickstart.app/Contents/Resources/Scripts/start.sh
@@ -1,8 +1,26 @@
 #!/bin/bash
 
+CONFIG_FILE="$HOME/.docker/vm.config"
+[[ -f $CONFIG_FILE ]] && source $CONFIG_FILE
+
+if [ "$PROVIDER" == "VMWare Fusion" ]; then
+  PROVIDER_CLI=/usr/local/bin/vmrun
+  STATUS_CMD="list | grep"
+  PROVIDER_PREFIX=vmwarefusion
+elif [ "$PROVIDER" == "Parallels Desktop" ]; then
+  PROVIDER_CLI=/usr/local/bin/prlctl
+  STATUS_CMD=status
+  PROVIDER_PREFIX=parallels
+  echo -e "\nIf you haven't install the docker-machine-parallels driver,\ncheck: https://github.com/Parallels/docker-machine-parallels/\n"
+else
+  PROVIDER="VirtualBox"
+  PROVIDER_CLI=/Applications/VirtualBox.app/Contents/MacOS/VBoxManage
+  STATUS_CMD=showvminfo
+  PROVIDER_PREFIX=virtualbox
+fi
+
 VM=default
 DOCKER_MACHINE=/usr/local/bin/docker-machine
-VBOXMANAGE=/Applications/VirtualBox.app/Contents/MacOS/VBoxManage
 
 BLUE='\033[0;34m'
 GREEN='\033[0;32m'
@@ -13,21 +31,30 @@ unset LD_LIBRARY_PATH
 
 clear
 
-if [ ! -f $DOCKER_MACHINE ] || [ ! -f $VBOXMANAGE ]; then
-  echo "Either VirtualBox or Docker Machine are not installed. Please re-run the Toolbox Installer and try again."
+if [ ! -f $DOCKER_MACHINE ]; then
+  echo "Docker Machine are not installed. Please re-run the Toolbox Installer and try again."
   exit 1
 fi
 
-$VBOXMANAGE showvminfo $VM &> /dev/null
+if [ ! -f $PROVIDER_CLI ]; then
+  if [ "$PROVIDER" == "VMWare Fusion" ] || [ "$PROVIDER" == "Parallels Desktop" ]; then
+    echo "$PROVIDER_CLI are not installed. Please make sure $PROVIDER's command line tool works properly and try again."
+  else
+    echo "$PROVIDER are not installed. Please re-run the Toolbox Installer and try again."
+  fi
+  exit 1
+fi
+
+$PROVIDER_CLI $STATUS_CMD $VM &> /dev/null
 VM_EXISTS_CODE=$?
 
-if [ $VM_EXISTS_CODE -eq 1 ]; then
+if [ $VM_EXISTS_CODE -eq 0 ]; then
+  echo "Machine $VM already exists in $PROVIDER."
+else
   echo "Creating Machine $VM..."
   $DOCKER_MACHINE rm -f $VM &> /dev/null
   rm -rf ~/.docker/machine/machines/$VM
-  $DOCKER_MACHINE create -d virtualbox --virtualbox-memory 2048 --virtualbox-disk-size 204800 $VM
-else
-  echo "Machine $VM already exists in VirtualBox."
+  $DOCKER_MACHINE create -d $PROVIDER_PREFIX --$PROVIDER_PREFIX-memory 2048 --$PROVIDER_PREFIX-disk-size 204800 $VM
 fi
 
 VM_STATUS=$($DOCKER_MACHINE status $VM)


### PR DESCRIPTION
This is for #107

  1. Read the config from `$HOME/.docker/vm.config`. Looking for `PROVIDER="Parallels Desktop"` or `PROVIDER="VMware Fusion"` then setup the command accordingly. 
  2. Only test the Parallels Desktops for OS X && PD 11. __Please test with VMWare before merge.__

Thanks!