### PR TITLE
docker-machine 0.5.3 - removing machine will ask for confirmation

### DIFF
--- a/osx/uninstall.sh
+++ b/osx/uninstall.sh
@@ -10,7 +10,7 @@ fi
 while true; do
   read -p "Remove all Docker Machine VMs? (Y/N): " yn
   case $yn in
-    [Yy]* ) docker-machine rm -f $(docker-machine ls -q); break;;
+    [Yy]* ) docker-machine rm -y -f $(docker-machine ls -q); break;;
     [Nn]* ) break;;
     * ) echo "Please answer yes or no."; exit 1;;
   esac

--- a/windows/delete.sh
+++ b/windows/delete.sh
@@ -6,7 +6,7 @@ clear
 
 cd "$(dirname "$BASH_SOURCE")"
 
-( set -x; ./docker-machine rm -f default ) || true
+( set -x; ./docker-machine rm -y -f default ) || true
 
 echo
 echo '[Press any key to exit]'

--- a/windows/start.sh
+++ b/windows/start.sh
@@ -27,7 +27,7 @@ set -e
 
 if [ $VM_EXISTS_CODE -eq 1 ]; then
   echo "Creating Machine $VM..."
-  $DOCKER_MACHINE rm -f $VM &> /dev/null || :
+  $DOCKER_MACHINE rm -y -f $VM &> /dev/null || :
   rm -rf ~/.docker/machine/machines/$VM
   $DOCKER_MACHINE create -d virtualbox $VM
 else


### PR DESCRIPTION
This PR fix a breaking change related to https://github.com/docker/machine/pull/2404. Where in `docker-machine` we now ask the user to confirm the removal of a machine.

As `toolbox` is removing quite a few machines, if we don't change anything, they won't be removed and probably stuck, waiting for user input.

The https://github.com/docker/machine/pull/2404 will be released with the `docker-machine` 0.5.3 which should happen on December 14th.