### PR TITLE
update maintainers file for parsing

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,3 +1,40 @@
-Jeff Morgan <jmorgan@docker.com> (@jeffdm)
-Sean Li <sean@docker.com>  (@lisean106)
-Michael Chiang <mchiang@docker.com> <@mchiang0610> 
+# Toolbox maintainers file
+#
+# This file describes who runs the docker/toolbox project and how.
+# This is a living document - if you see something out of date or missing, speak up!
+#
+# It is structured to be consumable by both humans and programs.
+# To extract its contents programmatically, use any TOML-compliant parser.
+#
+# This file is compiled into the MAINTAINERS file in docker/opensource.
+#
+[Org]
+	[Org."Core maintainers"]
+		people = [
+			"jeffdm",
+			"lisean106",
+			"mchiang0610",
+		]
+
+[people]
+
+# A reference list of all people associated with the project.
+# All other sections should refer to people by their canonical key
+# in the people section.
+
+	# ADD YOURSELF HERE IN ALPHABETICAL ORDER
+
+	[people.jeffdm]
+	Name = "Jeff Morgan"
+	Email = "jmorgan@docker.com"
+	GitHub = "jeffdm"
+
+	[people.lisean106]
+	Name = "Sean Li"
+	Email = "sean@docker.com"
+	GitHub = "lisean106"
+
+	[people.mchiang0610]
+	Name = "Michael Chiang"
+	Email = "mchiang@docker.com"
+	GitHub = "mchiang0610"


### PR DESCRIPTION
this updates the MAINTAINERS file to the new toml format,
so that it can be parsed and collected in the docker/opensource
repository.

see docker/opensource#35 and docker/docker#18321