### PR TITLE
add VirtualBox NDIS5 driver option to the installer

### DIFF
--- a/windows/Toolbox.iss
+++ b/windows/Toolbox.iss
@@ -53,6 +53,7 @@ Filename: "{win}\explorer.exe"; Parameters: "{userprograms}\Docker\"; Flags: pos
 Name: desktopicon; Description: "{cm:CreateDesktopIcon}"
 Name: modifypath; Description: "Add docker binaries to &PATH"
 Name: upgradevm; Description: "Upgrade Boot2Docker VM"
+Name: vbox_ndis5; Description: "Install VirtualBox with NDIS5 driver[default NDIS6]"; Flags: unchecked
 
 [Components]
 Name: "Docker"; Description: "Docker Client for Windows" ; Types: full custom; Flags: fixed
@@ -253,8 +254,14 @@ var
 	ResultCode: Integer;
 begin
 	WizardForm.FilenameLabel.Caption := 'installing VirtualBox'
-	if not Exec(ExpandConstant('msiexec'), ExpandConstant('/qn /i "{app}\installers\virtualbox\virtualbox.msi" /norestart'), '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
-		MsgBox('virtualbox install failure', mbInformation, MB_OK);
+	if IsTaskSelected('vbox_ndis5') then begin
+		if not Exec(ExpandConstant('msiexec'), ExpandConstant('/qn /i "{app}\installers\virtualbox\virtualbox.msi" NETWORKTYPE=NDIS5 /norestart'), '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+			MsgBox('virtualbox install failure', mbInformation, MB_OK);
+	end else begin
+		if not Exec(ExpandConstant('msiexec'), ExpandConstant('/qn /i "{app}\installers\virtualbox\virtualbox.msi" /norestart'), '', SW_HIDE, ewWaitUntilTerminated, ResultCode) then
+			MsgBox('virtualbox install failure', mbInformation, MB_OK);
+	end;
+
 end;
 
 procedure RunInstallGit();


### PR DESCRIPTION
NDIS6 host network filter diver is known to cause issues on some Windows
versions. VirtualBox installs The NDIS6 driver by default for Windows Vista and later.
For older Windows versions, the installer will automatically select the NDIS5
driver and this cannot be changed. This commit provides an option for Windows Vista
and later users to install the (legacy) NDIS5 host network filter driver.

Signed-off-by: Todor Minchev <todor.minchev@linux.intel.com>