### PR TITLE
Improve customization for unattended installation

### DIFF
--- a/windows/Toolbox.iss
+++ b/windows/Toolbox.iss
@@ -220,10 +220,8 @@ begin
   TrackingLabel.Top := TrackingCheckBox.Top + TrackingCheckBox.Height + 5;
   TrackingLabel.Height := 100;
 
-    // Don't do this until we can compare versions
-    // Wizardform.ComponentsList.Checked[3] := NeedToInstallVirtualBox();
-    Wizardform.ComponentsList.ItemEnabled[3] := not NeedToInstallVirtualBox();
-    Wizardform.ComponentsList.Checked[5] := NeedToInstallGit();
+  Wizardform.ComponentsList.ItemEnabled[3] := not NeedToInstallVirtualBox();
+  Wizardform.ComponentsList.ItemEnabled[5] := not NeedToInstallGit();
 end;
 
 function InitializeSetup(): boolean;


### PR DESCRIPTION
This is an attempt to address #322 by making it easier to control via the `/COMPONENTS` command-line option to the installer which optional components are installed.

Because the `Docker` and `DockerMachine` components are marked `fixed`, these components cannot be deselected with the `/COMPONENTS` option which I think is fine.  When it comes to other semi-optional components (namely VirtualBox and Git) it's a little trickier to decide what to do.

In this case I decided that if VBox or Git need to be installed, then their checkboxes will be grayed out, so an average user running the installer will be forced to select them (as they are selected by default).  However, this does _not_ stop the `/COMPONENTS` parameter from changing these selections, which still give administrators who (ostensibly) know what they're doing some control over what gets installed by the installer.  This was not the case when the `.Checked` property was being set manually, which would always override the selection via `/COMPONENTS`.

Open to other ideas as well but I think this is an improvement.  Unfortunately I can't find any way in Inno Setup to query what was _explicitly_ selected or deslected via `/COMPONENTS`.
