### PR TITLE
Re-enable welcome page

### DIFF
--- a/windows/Toolbox.iss
+++ b/windows/Toolbox.iss
@@ -28,6 +28,7 @@ ArchitecturesInstallIn64BitMode=x64
 DefaultDirName={pf}\{#MyAppName}
 DefaultGroupName=Docker
 DisableProgramGroupPage=yes
+DisableWelcomePage=no
 OutputBaseFilename=DockerToolbox
 Compression=lzma
 SolidCompression=yes


### PR DESCRIPTION
The 'Welcome' page, which among other things displays the error reporting / tracking checkbox, was not being displayed when running the installer.

I'm actually a little confused about this, because I could have sworn I remember seeing this when running the Docker Toolbox installer in the past.  However, now I am certain it is not displaying the welcome page.

There was a possibility this page was being skipped due to there already being a record of my having installed Docker Toolbox in the windows registry.  However, looking through the Inno Setup source code it's clear that the *only* way the welcome page would be skipped is if `DisableWelcomePage=yes`, which for some reason happens to be the default.

Signed-off-by: Erik M. Bray <erik.bray@lri.fr>