### PR TITLE
Fix issue `docker run image bash -c "multiple parameters"`

### DIFF
--- a/windows/start.sh
+++ b/windows/start.sh
@@ -59,7 +59,7 @@ echo
 cd
 
 docker () {
-  MSYS_NO_PATHCONV=1 docker.exe $@
+  MSYS_NO_PATHCONV=1 docker.exe "$@"
 }
 export -f docker
 


### PR DESCRIPTION
This is a fix to https://github.com/docker/toolbox/issues/368.

Thanks to @Bakudankun who found how to correct the problem.