### PR TITLE
fixes wrong path evaluation

### DIFF
--- a/windows/start.sh
+++ b/windows/start.sh
@@ -46,13 +46,13 @@ if [ $VM_EXISTS_CODE -eq 1 ]; then
   "${DOCKER_MACHINE}" create -d virtualbox $PROXY_ENV "${VM}"
 fi
 
-VM_STATUS="$(${DOCKER_MACHINE} status ${VM} 2>&1)"
+VM_STATUS="$("${DOCKER_MACHINE}" status ${VM} 2>&1)"
 if [ "${VM_STATUS}" != "Running" ]; then
   "${DOCKER_MACHINE}" start "${VM}"
   yes | "${DOCKER_MACHINE}" regenerate-certs "${VM}"
 fi
 
-eval "$(${DOCKER_MACHINE} env --shell=bash ${VM})"
+eval "$("${DOCKER_MACHINE}" env --shell=bash ${VM})"
 
 clear
 cat << EOF

--- a/windows/start.sh
+++ b/windows/start.sh
@@ -68,7 +68,7 @@ cat << EOF
               \____\_______/
 
 EOF
-echo -e "${BLUE}docker${NC} is configured to use the ${GREEN}${VM}${NC} machine with IP ${GREEN}$(${DOCKER_MACHINE} ip ${VM})${NC}"
+echo -e "${BLUE}docker${NC} is configured to use the ${GREEN}${VM}${NC} machine with IP ${GREEN}$("${DOCKER_MACHINE}" ip ${VM})${NC}"
 echo "For help getting started, check out the docs at https://docs.docker.com"
 echo
 cd


### PR DESCRIPTION
Please use the "bash -x" for development and watch the path expansions for absolut paths with spaces.
Maybe someone wants to copy and customize the start.sh. For example to modify machine-storage location or using another docker-machine version.
Maybe you want to try to set a concrete docker-machine executable with spaces.
`DOCKER_MACHINE=c:\\Program\ Files\\Docker\ Toolbox\\docker-machine.exe`
Than your script is running into the trap
`++ 'c:\Program' 'Files\Docker' 'Toolbox\docker-machine.exe' status prj123`
`+ VM_STATUS='bash: c:\Program: No such file or directory'`
`+ '[' 127 -eq 0 ']'`
`+ read -p 'Looks like something went wrong... Press any key to continue...'`
`Looks like something went wrong... Press any key to continue...`

The fix will make it work as expected:
`++ 'c:\Program Files\Docker Toolbox\docker-machine.exe' status prj123`
`+ VM_STATUS=Running`
`++ 'c:\Program Files\Docker Toolbox\docker-machine.exe' env --shell=bash prj123`
`+ eval 'export DOCKER_TLS_VERIFY="1"`
