### PR TITLE
Allowing you to override 'default' as the name for a machine 

### DIFF
--- a/windows/start.sh
+++ b/windows/start.sh
@@ -2,7 +2,7 @@
 
 trap '[ "$?" -eq 0 ] || read -p "Looks like something went wrong... Press any key to continue..."' EXIT
 
-VM=default
+VM=${DOCKER_MACHINE_NAME-default}
 DOCKER_MACHINE=./docker-machine.exe
 
 if [ ! -z "$VBOX_MSI_INSTALL_PATH" ]; then


### PR DESCRIPTION
using the env variable VMNAME

Replacement for https://github.com/docker/toolbox/pull/426

@nathanleclaire 

Signed-off-by: Markos Rendell <markosrendell@gmail.com>