### PR TITLE
HTTP_PROXY -> DOCKER_HTTP_PROXY

### DIFF
--- a/windows/start.sh
+++ b/windows/start.sh
@@ -39,21 +39,21 @@ if [ $VM_EXISTS_CODE -eq 1 ]; then
 
   #set proxy variables if they exists
   if [ -n "${DOCKER_HTTP_PROXY}" ]; then
-  PROXY_ENV="$PROXY_ENV --engine-env HTTP_PROXY=$DOCKER_HTTP_PROXY"
+    PROXY_ENV="$PROXY_ENV --engine-env HTTP_PROXY=$DOCKER_HTTP_PROXY"
   elif [ -n "${HTTP_PROXY}" ]; then
-  PROXY_ENV="$PROXY_ENV --engine-env HTTP_PROXY=$HTTP_PROXY"
+    PROXY_ENV="$PROXY_ENV --engine-env HTTP_PROXY=$HTTP_PROXY"
   fi
 
   if [ -n "${DOCKER_HTTPS_PROXY}" ]; then
-	PROXY_ENV="$PROXY_ENV --engine-env HTTPS_PROXY=$DOCKER_HTTPS_PROXY"
+    PROXY_ENV="$PROXY_ENV --engine-env HTTPS_PROXY=$DOCKER_HTTPS_PROXY"
   elif [ -n "${HTTPS_PROXY}" ]; then
-  PROXY_ENV="$PROXY_ENV --engine-env HTTP_PROXY=$HTTPS_PROXY"
+    PROXY_ENV="$PROXY_ENV --engine-env HTTP_PROXY=$HTTPS_PROXY"
   fi
 
   if [ -n "${DOCKER_NO_PROXY}" ]; then
-	PROXY_ENV="$PROXY_ENV --engine-env NO_PROXY=$DOCKER_NO_PROXY"
+    PROXY_ENV="$PROXY_ENV --engine-env NO_PROXY=$DOCKER_NO_PROXY"
   elif [ -n "${NO_PROXY}" ]; then
-	PROXY_ENV="$PROXY_ENV --engine-env NO_PROXY=$NO_PROXY"
+    PROXY_ENV="$PROXY_ENV --engine-env NO_PROXY=$NO_PROXY"
   fi
 
   "${DOCKER_MACHINE}" create -d virtualbox $PROXY_ENV "${VM}"

--- a/windows/start.sh
+++ b/windows/start.sh
@@ -36,16 +36,26 @@ STEP="Checking if machine $VM exists"
 if [ $VM_EXISTS_CODE -eq 1 ]; then
   "${DOCKER_MACHINE}" rm -f "${VM}" &> /dev/null || :
   rm -rf ~/.docker/machine/machines/"${VM}"
+
   #set proxy variables if they exists
-  if [ -n ${DOCKER_HTTP_PROXY+x} ]; then
-	PROXY_ENV="$PROXY_ENV --engine-env HTTP_PROXY=$DOCKER_HTTP_PROXY"
+  if [ -n "${DOCKER_HTTP_PROXY}" ]; then
+  PROXY_ENV="$PROXY_ENV --engine-env HTTP_PROXY=$DOCKER_HTTP_PROXY"
+  elif [ -n "${HTTP_PROXY}" ]; then
+  PROXY_ENV="$PROXY_ENV --engine-env HTTP_PROXY=$HTTP_PROXY"
   fi
-  if [ -n ${DOCKER_HTTPS_PROXY+x} ]; then
+
+  if [ -n "${DOCKER_HTTPS_PROXY}" ]; then
 	PROXY_ENV="$PROXY_ENV --engine-env HTTPS_PROXY=$DOCKER_HTTPS_PROXY"
+  elif [ -n "${HTTPS_PROXY}" ]; then
+  PROXY_ENV="$PROXY_ENV --engine-env HTTP_PROXY=$HTTPS_PROXY"
   fi
-  if [ -n ${DOCKER_NO_PROXY+x} ]; then
+
+  if [ -n "${DOCKER_NO_PROXY}" ]; then
 	PROXY_ENV="$PROXY_ENV --engine-env NO_PROXY=$DOCKER_NO_PROXY"
-  fi  
+  elif [ -n "${NO_PROXY}" ]; then
+	PROXY_ENV="$PROXY_ENV --engine-env NO_PROXY=$NO_PROXY"
+  fi
+
   "${DOCKER_MACHINE}" create -d virtualbox $PROXY_ENV "${VM}"
 fi
 

--- a/windows/start.sh
+++ b/windows/start.sh
@@ -37,14 +37,14 @@ if [ $VM_EXISTS_CODE -eq 1 ]; then
   "${DOCKER_MACHINE}" rm -f "${VM}" &> /dev/null || :
   rm -rf ~/.docker/machine/machines/"${VM}"
   #set proxy variables if they exists
-  if [ -n ${HTTP_PROXY+x} ]; then
-	PROXY_ENV="$PROXY_ENV --engine-env HTTP_PROXY=$HTTP_PROXY"
+  if [ -n ${DOCKER_HTTP_PROXY+x} ]; then
+	PROXY_ENV="$PROXY_ENV --engine-env HTTP_PROXY=$DOCKER_HTTP_PROXY"
   fi
-  if [ -n ${HTTPS_PROXY+x} ]; then
-	PROXY_ENV="$PROXY_ENV --engine-env HTTPS_PROXY=$HTTPS_PROXY"
+  if [ -n ${DOCKER_HTTPS_PROXY+x} ]; then
+	PROXY_ENV="$PROXY_ENV --engine-env HTTPS_PROXY=$DOCKER_HTTPS_PROXY"
   fi
-  if [ -n ${NO_PROXY+x} ]; then
-	PROXY_ENV="$PROXY_ENV --engine-env NO_PROXY=$NO_PROXY"
+  if [ -n ${DOCKER_NO_PROXY+x} ]; then
+	PROXY_ENV="$PROXY_ENV --engine-env NO_PROXY=$DOCKER_NO_PROXY"
   fi  
   "${DOCKER_MACHINE}" create -d virtualbox $PROXY_ENV "${VM}"
 fi


### PR DESCRIPTION
Hey Guys, 

I like the {HTTP,HTTPS,NO}_PROXY logic but it's sometimes not suitable. If the user is running a proxy on localhost (cntlm for example) the docker-machine HTTP_PROXY env variable will be set to http://localhost:3128 which isn't really what the user wants. 

I think it might be a good idea to allow users to specify DOCKER_{HTTP,HTTPS,NO}_PROXY so they can specify http://10.0.2.2:3128 to use the hosts locally installed proxy. There may also be other edge cases such as wanting to route dacker traffic via a different proxy to analyse traffic from containers etc... 

Thanks, 

Tim Birkett