### PR TITLE
convert docs Dockerfiles to use docs/base:oss

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,17 +1,8 @@
-FROM docs/base:latest
+FROM docs/base:oss
 MAINTAINER Mary Anthony <mary@docker.com> (@moxiegirl)
-
-RUN svn checkout https://github.com/docker/docker/trunk/docs /docs/content/engine
-RUN svn checkout https://github.com/docker/compose/trunk/docs /docs/content/compose
-RUN svn checkout https://github.com/docker/machine/trunk/docs /docs/content/machine
-RUN svn checkout https://github.com/docker/swarm/trunk/docs /docs/content/swarm
-RUN svn checkout https://github.com/docker/distribution/trunk/docs /docs/content/registry
-RUN svn checkout https://github.com/docker/kitematic/trunk/docs /docs/content/kitematic
-RUN svn checkout https://github.com/docker/notary/trunk/docs /docs/content/notary
-RUN svn checkout https://github.com/docker/opensource/trunk/docs /docs/content/opensource
 
 ENV PROJECT=toolbox
 # to get the git info for this repo
 COPY . /src
-
+RUN rm -r /docs/content/$PROJECT/
 COPY . /docs/content/$PROJECT/


### PR DESCRIPTION
speeds up `make docs`, and reduces the svn checkout timeout issue.