### PR TITLE
Force Toolbox bin path to start of PATH

### DIFF
--- a/windows/start.sh
+++ b/windows/start.sh
@@ -2,6 +2,10 @@
 
 trap '[ "$?" -eq 0 ] || read -p "Looks like something went wrong in step ´$STEP´... Press any key to continue..."' EXIT
 
+# TODO: I'm sure this is not very robust.  But, it is needed for now to ensure
+# that binaries provided by Docker Toolbox over-ride binaries provided by
+# Docker for Windows when launching using the Quickstart.
+export PATH="/c/Program Files/Docker Toolbox:$PATH"
 VM=${DOCKER_MACHINE_NAME-default}
 DOCKER_MACHINE=./docker-machine.exe
 


### PR DESCRIPTION
Just for reference @dgageot @rneugeba -- I noticed that the PATH for binaries set by Docker for Windows clobbers the path for Toolbox binaries (this may or may not be the behavior for all installs, but it was for my existing Toolbox-D4W VM).  So, my versions of everything were off when I installed the Toolbox RC.  This patch should fix the behavior for users of the "Quickstart" terminal but it's possible some users will hit this issue through other means, so be advised.

Signed-off-by: Nathan LeClaire <nathan.leclaire@gmail.com>