### PR TITLE
improve proxy variables check

### DIFF
--- a/osx/mpkg/quickstart.app/Contents/Resources/Scripts/start.sh
+++ b/osx/mpkg/quickstart.app/Contents/Resources/Scripts/start.sh
@@ -30,15 +30,15 @@ if [ $VM_EXISTS_CODE -eq 1 ]; then
   "${DOCKER_MACHINE}" rm -f "${VM}" &> /dev/null
   rm -rf ~/.docker/machine/machines/"${VM}"
   #set proxy variables if they exists
-  if [ -n ${HTTP_PROXY+x} ]; then
-	PROXY_ENV="$PROXY_ENV --engine-env HTTP_PROXY=$HTTP_PROXY"
+  if [ "${HTTP_PROXY}" ]; then
+    PROXY_ENV="$PROXY_ENV --engine-env HTTP_PROXY=$HTTP_PROXY"
   fi
-  if [ -n ${HTTPS_PROXY+x} ]; then
-	PROXY_ENV="$PROXY_ENV --engine-env HTTPS_PROXY=$HTTPS_PROXY"
+  if [ "${HTTPS_PROXY}" ]; then
+    PROXY_ENV="$PROXY_ENV --engine-env HTTPS_PROXY=$HTTPS_PROXY"
   fi
-  if [ -n ${NO_PROXY+x} ]; then
-	PROXY_ENV="$PROXY_ENV --engine-env NO_PROXY=$NO_PROXY"
-  fi  
+  if [ "${NO_PROXY}" ]; then
+    PROXY_ENV="$PROXY_ENV --engine-env NO_PROXY=$NO_PROXY"
+  fi
   "${DOCKER_MACHINE}" create -d virtualbox $PROXY_ENV --virtualbox-memory 2048 --virtualbox-disk-size 204800 "${VM}"
 fi
 

--- a/windows/start.sh
+++ b/windows/start.sh
@@ -41,15 +41,15 @@ if [ $VM_EXISTS_CODE -eq 1 ]; then
   "${DOCKER_MACHINE}" rm -f "${VM}" &> /dev/null || :
   rm -rf ~/.docker/machine/machines/"${VM}"
   #set proxy variables if they exists
-  if [ -n ${HTTP_PROXY+x} ]; then
-	PROXY_ENV="$PROXY_ENV --engine-env HTTP_PROXY=$HTTP_PROXY"
+  if [ "${HTTP_PROXY}" ]; then
+    PROXY_ENV="$PROXY_ENV --engine-env HTTP_PROXY=$HTTP_PROXY"
   fi
-  if [ -n ${HTTPS_PROXY+x} ]; then
-	PROXY_ENV="$PROXY_ENV --engine-env HTTPS_PROXY=$HTTPS_PROXY"
+  if [ "${HTTPS_PROXY}" ]; then
+    PROXY_ENV="$PROXY_ENV --engine-env HTTPS_PROXY=$HTTPS_PROXY"
   fi
-  if [ -n ${NO_PROXY+x} ]; then
-	PROXY_ENV="$PROXY_ENV --engine-env NO_PROXY=$NO_PROXY"
-  fi  
+  if [ "${NO_PROXY}" ]; then
+    PROXY_ENV="$PROXY_ENV --engine-env NO_PROXY=$NO_PROXY"
+  fi
   "${DOCKER_MACHINE}" create -d virtualbox $PROXY_ENV "${VM}"
 fi
 


### PR DESCRIPTION
* Fix `if` statements - based on my tests and https://stackoverflow.com/questions/3869072/test-for-non-zero-length-string-in-bash-n-var-or-var the current method will always return true even if `PROXY` environment variables are not set
  * Improves on https://github.com/docker/toolbox/pull/183
* Replace inconsistent tabs in `start.sh` with spaces like exists elsewhere in `start.sh`