### PR TITLE
set no proxy flag - exclude machine from proxy

### DIFF
--- a/osx/mpkg/quickstart.app/Contents/Resources/Scripts/start.sh
+++ b/osx/mpkg/quickstart.app/Contents/Resources/Scripts/start.sh
@@ -48,7 +48,7 @@ if [ "${VM_STATUS}" != "Running" ]; then
   yes | "${DOCKER_MACHINE}" regenerate-certs "${VM}"
 fi
 
-eval "$(${DOCKER_MACHINE} env --shell=bash ${VM})"
+eval "$(${DOCKER_MACHINE} env --shell=bash --no-proxy ${VM})"
 
 clear
 cat << EOF

--- a/windows/start.sh
+++ b/windows/start.sh
@@ -61,7 +61,7 @@ if [ "${VM_STATUS}" != "Running" ]; then
 fi
 
 STEP="Setting env"
-eval "$(${DOCKER_MACHINE} env --shell=bash ${VM})"
+eval "$(${DOCKER_MACHINE} env --shell=bash --no-proxy ${VM})"
 
 STEP="Finalize"
 clear


### PR DESCRIPTION
Set `--no-proxy` flag as documented at https://docs.docker.com/machine/reference/env/#/excluding-the-created-machine-from-proxies. Fixes issues many people have when using a proxy.

Originally suggested by @nathanleclaire at https://github.com/docker/toolbox/pull/183#issuecomment-197066248 