### PR TITLE
document how to install registry custom CA

### DIFF
--- a/docs/faqs/troubleshoot.md
+++ b/docs/faqs/troubleshoot.md
@@ -158,4 +158,20 @@ Here is an example of creating a `default` machine with proxies set to `http://e
 
 To learn more about using `docker-machine create`, see the [create](https://docs.docker.com/machine/reference/create/) command in the [Docker Machine](https://docs.docker.com/machine/overview/) reference.
 
+## Custom root Certificate Authority for Registry
+
+Users using their own Docker Registry will experience `x509: certificate signed by unknown authority` 
+error messages if their registry is signed by custom root Certificate Authority and it is 
+not registered with Docker Engine. As discussed in the [Docker Engine documentation](https://docs.docker.com/engine/security/certificates/#/understanding-the-configuration)
+certificates should be placed at `/etc/docker/certs.d/hostname/ca.crt` 
+where `hostname` is your Registry server's hostname.
+
+```console
+docker-machine scp certfile default:ca.crt
+docker-machine ssh default
+sudo mv ~/ca.crt /etc/docker/certs.d/hostname/ca.crt
+exit
+docker-machine restart
+```
+
 &nbsp;


### PR DESCRIPTION
Document how to install custom CA for registry. This is needed to address `x509: certificate signed by unknown authority` error messages.

Related to https://github.com/boot2docker/boot2docker/issues/347, https://github.com/docker/machine/issues/2247, https://github.com/docker/machine/issues/1799, https://github.com/docker/machine/issues/1963, https://github.com/docker/machine/issues/1872, https://github.com/docker/machine/pull/3690, https://github.com/boot2docker/boot2docker/pull/1195
