### PR TITLE
Update to uninstall Docker Quickstart Terminal and Kitematic dependencies

### DIFF
--- a/osx/uninstall.sh
+++ b/osx/uninstall.sh
@@ -33,5 +33,7 @@ pkgutil --forget io.docker.pkg.docker
 pkgutil --forget io.docker.pkg.dockercompose
 pkgutil --forget io.docker.pkg.dockermachine
 pkgutil --forget io.boot2dockeriso.pkg.boot2dockeriso
+pkgutil --forget io.docker.pkg.dockerquickstartterminalapp
+pkgutil --forget io.docker.pkg.kitematicapp
 
 echo "All Done!"


### PR DESCRIPTION
Docker Quickstart Terminal and Kitematic are also installed during the Docker Toolbox v1.12.0 installation process. All traces of them should also be removed when Docker Toolbox is uninstalled.
