### PR TITLE
[Windows] A More robuse "Docker Quickstart Terminal"

### DIFF
--- a/windows/Toolbox.iss
+++ b/windows/Toolbox.iss
@@ -89,6 +89,7 @@ Type: filesandordirs; Name: "{localappdata}\..\Roaming\Kitematic"
 
 [Registry]
 Root: HKCU; Subkey: "Environment"; ValueType:string; ValueName:"DOCKER_TOOLBOX_INSTALL_PATH"; ValueData:"{app}" ; Flags: preservestringtype uninsdeletevalue;
+Root: HKCU; Subkey: "Environment"; ValueType: expandsz; ValueName: "Path"; ValueData: "{olddata};{app}"
 
 [Code]
 #include "base64.iss"

--- a/windows/docker-terminal.cmd
+++ b/windows/docker-terminal.cmd
@@ -1,0 +1,3 @@
+@echo off
+
+"C:\Program Files\Git\bin\bash.exe" -c " \"/c/Program Files/Docker Toolbox/start.sh\" \"%*\"" 

--- a/windows/start.sh
+++ b/windows/start.sh
@@ -2,12 +2,21 @@
 
 trap '[ "$?" -eq 0 ] || read -p "Looks like something went wrong in step ´$STEP´... Press any key to continue..."' EXIT
 
-# TODO: I'm sure this is not very robust.  But, it is needed for now to ensure
-# that binaries provided by Docker Toolbox over-ride binaries provided by
+#Quick Hack: used to convert e.g. "C:\Program Files\Docker Toolbox" to "/c/Program Files/Docker Toolbox"
+win_to_unix_path(){ 
+	wd="$(pwd)"
+	cd "$1"
+		the_path="$(pwd)"
+	cd "$wd"
+	echo $the_path
+}
+
+# This is needed  to ensure that binaries provided
+# by Docker Toolbox over-ride binaries provided by
 # Docker for Windows when launching using the Quickstart.
-export PATH="/c/Program Files/Docker Toolbox:$PATH"
+export PATH="$(win_to_unix_path "${DOCKER_TOOLBOX_INSTALL_PATH}"):$PATH"
 VM=${DOCKER_MACHINE_NAME-default}
-DOCKER_MACHINE=./docker-machine.exe
+DOCKER_MACHINE="${DOCKER_TOOLBOX_INSTALL_PATH}\docker-machine.exe"
 
 STEP="Looking for vboxmanage.exe"
 if [ ! -z "$VBOX_MSI_INSTALL_PATH" ]; then
@@ -61,14 +70,15 @@ if [ $VM_EXISTS_CODE -eq 1 ]; then
 fi
 
 STEP="Checking status on $VM"
-VM_STATUS="$( set +e ; ${DOCKER_MACHINE} status ${VM} )"
+VM_STATUS="$( set +e ; "${DOCKER_MACHINE}" status "${VM}" )"
 if [ "${VM_STATUS}" != "Running" ]; then
   "${DOCKER_MACHINE}" start "${VM}"
   yes | "${DOCKER_MACHINE}" regenerate-certs "${VM}"
 fi
 
 STEP="Setting env"
-eval "$(${DOCKER_MACHINE} env --shell=bash --no-proxy ${VM})"
+eval "$("${DOCKER_MACHINE}" env --shell=bash --no-proxy "${VM}" | sed -e "s/export/SETX/g" | sed -e "s/=/ /g")" &> /dev/null #for persistent Environment Variables, available in next sessions
+eval "$("${DOCKER_MACHINE}" env --shell=bash --no-proxy "${VM}")" #for transient Environment Variables, available in current session
 
 STEP="Finalize"
 clear
@@ -85,10 +95,11 @@ cat << EOF
               \____\_______/
 
 EOF
-echo -e "${BLUE}docker${NC} is configured to use the ${GREEN}${VM}${NC} machine with IP ${GREEN}$(${DOCKER_MACHINE} ip ${VM})${NC}"
+echo -e "${BLUE}docker${NC} is configured to use the ${GREEN}${VM}${NC} machine with IP ${GREEN}$("${DOCKER_MACHINE}" ip ${VM})${NC}"
 echo "For help getting started, check out the docs at https://docs.docker.com"
 echo
-cd
+echo 
+#cd #Bad: working dir should be whatever directory was invoked from rather than fixed to the Home folder
 
 docker () {
   MSYS_NO_PATHCONV=1 docker.exe "$@"


### PR DESCRIPTION
**Applies to Windows only**

This PR is the culmination of a few changes I made in to my docker toolbox build and setup, in order to be able to easily use `docker`, `docker-compose`  from any terminal in windows i.e. cmd, powershell, git-bash etc

It is quite tedious to only have access to the `docker` command through the "Docker Quickstart Terminal" (DQT) on the start menu. Moreover DQT is setup to start from the same directory each time; in real day-to-day work, this is almost never the directory you want to be in.

I have made changes to the start.sh script to make it portable. I have also introduced the file docker-terminal.cmd which simply runs the start.sh.. The advantage of docker-terminal is that one can simply open up their project in a specific directory (e.g. with "Open command window here" or "Git bash here") and run `docker-terminal` from either powershell or command prompt (or git-bash), and this will run the start.sh script: no need to go to you start menu to look for Quickstart Terminal! 

What's even better is you only need to run docker-terminal once. Thereafter, you can now use docker, docker-compose etc from powershell or cmd and not rely on having to use the DQT git-bash.

I'd like to invite constructive advice and improvements to this wherever you all feel it can be better!
Thanks!
