### PR TITLE
GitHub release

### DIFF
--- a/script/release.sh
+++ b/script/release.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/script/release.sh
+++ b/script/release.sh
@@ -11,6 +11,7 @@ fi
 . versions
 TAG="v${INSTALLER_VERSION}"
 REMOTE="git@github.com:docker/toolbox"
+command -v go >/dev/null || { echo "go (https://golang.org/doc/install) needs to be installed"; exit 1; }
 go get -u github.com/aktau/github-release
 
 case $1 in

--- a/script/release.sh
+++ b/script/release.sh
@@ -11,6 +11,7 @@ fi
 . versions
 TAG="v${INSTALLER_VERSION}"
 REMOTE="git@github.com:docker/toolbox"
+go get github.com/aktau/github-release
 
 case $1 in
 create)

--- a/script/release.sh
+++ b/script/release.sh
@@ -11,7 +11,7 @@ fi
 . versions
 TAG="v${INSTALLER_VERSION}"
 REMOTE="git@github.com:docker/toolbox"
-go get github.com/aktau/github-release
+go get -u github.com/aktau/github-release
 
 case $1 in
 create)


### PR DESCRIPTION
Some feedback on the release tool:
- Needs to be ran from root directory
- got the following error the first time I ran it: `./script/release.sh: line 21: github-release: command not found`

The above didn't have any info, thus I assumed you had installed this: go get github.com/aktau/github-release