### PR TITLE
Correct path to remove /Applications/Docker.app

### DIFF
--- a/osx/uninstall.sh
+++ b/osx/uninstall.sh
@@ -17,7 +17,7 @@ while true; do
 done
 
 echo "Removing Applications..."
-rm -rf /Applications/Docker
+rm -rf /Applications/Docker.app
 
 echo "Removing docker binaries..."
 rm -f /usr/local/bin/docker


### PR DESCRIPTION
An `rm -rf` of `/Applications/Docker` passes silently, but doesn't remove `/Applications/Docker.app`