### PR TITLE
Don't start container before copy

### DIFF
--- a/script/build-osx
+++ b/script/build-osx
@@ -16,7 +16,7 @@ docker build \
 	--build-arg VBOX_REV="${VBOX_REV}" \
 	--build-arg MIXPANEL_TOKEN="${MIXPANEL_TOKEN}" \
 	.
-CONTAINER="$(docker run -d osx-installer)"
+CONTAINER="$(docker create osx-installer)"
 mkdir -p dist
 docker cp "${CONTAINER}":/DockerToolbox.pkg dist/
 docker rm "${CONTAINER}" 2>/dev/null || true

--- a/script/build-windows
+++ b/script/build-windows
@@ -17,7 +17,7 @@ docker build \
 	--build-arg VBOX_REV="${VBOX_REV}" \
 	--build-arg MIXPANEL_TOKEN="${MIXPANEL_TOKEN}" \
 	.
-CONTAINER="$(docker run -d windows-installer)"
+CONTAINER="$(docker create windows-installer)"
 mkdir -p dist
 docker cp "${CONTAINER}":/installer/Output/DockerToolbox.exe dist/
 docker rm "${CONTAINER}" 2>/dev/null || true


### PR DESCRIPTION
`docker cp` does not require the container to be running, so just _create_ the container instead of running it.
