### PR TITLE
use MSYS2_ARG_CONV_EXCL to avoid convertion for paths

### DIFF
--- a/windows/start.sh
+++ b/windows/start.sh
@@ -91,7 +91,7 @@ echo
 cd
 
 docker () {
-  MSYS_NO_PATHCONV=1 docker.exe "$@"
+  MSYS2_ARG_CONV_EXCL='*' MSYS_NO_PATHCONV=1 docker.exe "$@"
 }
 export -f docker
 


### PR DESCRIPTION
MSYS_NO_PATHCONV=1 is not enough to avoid conversion for paths. `docker run -it centos /bin/bash` is converted to `docker run -it centos /usr/bin/bash.exe`.