### PR TITLE
translate mount type=bind spec'd paths (windows)

### DIFF
--- a/windows/start.sh
+++ b/windows/start.sh
@@ -102,7 +102,12 @@ echo
 #cd #Bad: working dir should be whatever directory was invoked from rather than fixed to the Home folder
 
 docker () {
-  MSYS_NO_PATHCONV=1 docker.exe "$@"
+  args=()
+  for arg in "$@"
+  do
+    args+="$(echo $arg | sed -e 's/type=bind,\(source\|src\)=\([A-Za-z]\):\\\\/type=bind,\1=\/\L\2\//' | sed -e 's/\([[:print:]]\)\\/\1\//') "
+  done
+  MSYS_NO_PATHCONV=1 docker.exe $args
 }
 export -f docker
 


### PR DESCRIPTION
For #742.

This kind of works, I think.  Only for `--mount`, assumes drive is (or used directories of are) shared in the VIrtuaBox guest at the root of the FS by lowercase drive letter: `Z:\` ⇒ `/z`

But, this doesn't solve my issue.  My situation runs the `docker.exe` binary directly, and thus this Bash function doesn't run there.