### PR TITLE
Fix 'unexpected token' error

### DIFF
--- a/windows/start.sh
+++ b/windows/start.sh
@@ -101,7 +101,7 @@ echo
 echo 
 #cd #Bad: working dir should be whatever directory was invoked from rather than fixed to the Home folder
 
-docker () {
+function docker () {
   MSYS_NO_PATHCONV=1 docker.exe "$@"
 }
 export -f docker


### PR DESCRIPTION
- Windows 10 Home v1903
- Docker Toolbox v19.03.1

After install Docker Toolbox, I opened 'Quickstart Docker Terminal' and an error occurred.

```
bash: C:\Program Files\Docker Toolbox\start.sh: line 104: syntax error near unexpected token `('
Looks like something went wrong in step ´Finalize´... Press any key to continue...
```

I have identified the cause of the problem.
Please check my pull request. Thank you.